### PR TITLE
Enable ssl

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,5 +5,9 @@
     "database": "",
     "user": "",
     "password": ""
+  },
+  "ssl": {
+    "enabled": false,
+    "rejectUnauthorized": false
   }
 }

--- a/config/example.json
+++ b/config/example.json
@@ -5,5 +5,9 @@
     "database": "spatial",
     "user": "postgres",
     "password": "postgres"
+  },
+  "ssl": {
+    "enabled": false,
+    "rejectUnauthorized": false
   }
 }

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -4,13 +4,18 @@ const config = require('config')
 const pgPromise = require('pg-promise')
 const { Data } = require('./repo')
 
+const ssl = (process.env.SSL_ENABLED || config.ssl.enabled) && {
+  rejectUnauthorized: (process.env.REJECT_UNAUTHORIZED || config.ssl.rejectUnauthorized) || false
+};
+
 // Database connection details;
 const cn = {
   host: process.env.PG_HOST || config.db.host,
   port: process.env.PG_PORT || config.db.port,
   database: process.env.PG_DATABASE || config.db.database,
   user: process.env.PG_USER || config.db.user,
-  password: process.env.PG_PASSWORD || config.db.password
+  password: process.env.PG_PASSWORD || config.db.password,
+  ssl,
 }
 
 const initOptions = {

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -14,8 +14,8 @@ Model.prototype.getData = (req, callback) => {
 
   db.data.getGeometryColumnName(schema, table)
     .then(result => {
-      const geom = result.f_geometry_column
-      const srid = result.srid
+      const geom = result?.f_geometry_column || 'null'
+      const srid = result?.srid || 'null'
 
       db.data.createGeoJson(id, geom, srid, schema + '.' + table)
         .then(result => {


### PR DESCRIPTION
Enable SSL connections to the database

Add an `ssl` object based on [`ISSLConfig`
interface](https://github.com/vitaly-t/pg-promise/blob/master/typescript/pg-subset.d.ts#L62-L72)

Allow for `null` geometry and srid

ESRI Feature Services can support tables, which have no geometry. This
change keeps the provider from erroring when reading postgres tables
that have no geometry but can still be served as a Feature Layer