### PR TITLE
added npmignore to reduce package size in npm pack

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.DS_Store
+.git
+.github
+.idea
+.editorconfig
+.eslint*
+.nyc_output
+
+assets/
+coverage/
+docs/
+test/


### PR DESCRIPTION
package was published with `.github` and `assets` folders.

Before:
```
npm notice filename: koop-provider-pg-1.0.9.tgz
npm notice package size: 640.5 kB
npm notice unpacked size: 655.9 kB
```

After:
```
npm notice filename: koop-provider-pg-1.0.9.tgz
npm notice package size: 9.8 kB
npm notice unpacked size: 25.8 kB
```

98.4699% size reduction