### PR TITLE
Fix model getData method pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "bluebird": "^3.7.2",
         "config": "^3.3.8",
         "koop": "^5.1.0",
         "lodash": "^4.17.21",
@@ -2739,12 +2738,6 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint": "eslint . --ext .js"
   },
   "dependencies": {
-    "bluebird": "^3.7.2",
     "config": "^3.3.8",
     "koop": "^5.1.0",
     "lodash": "^4.17.21",

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -1,4 +1,3 @@
-const promise = require('bluebird')
 const config = require('config')
 
 const pgPromise = require('pg-promise')
@@ -14,8 +13,6 @@ const cn = {
 }
 
 const initOptions = {
-  promiseLib: promise,
-
   extend (obj, dc) {
     obj.data = new Data(obj, pgp)
   }

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -8,25 +8,35 @@ const log = createLogger('Model')
 class Model {
   constructor() { }
 
-  async getData(req, callback) {
-    let schema, table, id
-    
+  getData(req, callback) {
+    const splitPath = req.params.id.split('.');
+    const schema = splitPath[0];
+    const table = splitPath[1];
+    const id = process.env.PG_OBJECTID || 'gid';
+    const pgLimit = process.env.PG_LIMIT || 10000000;
+
+    if (!table) {
+      const error = new ValidationError('The "id" parameter must be in the form of "schema.table"', { 
+        providedId: req.params.id,
+        schema,
+        table 
+      });
+      log.warn('Request validation failed', { 
+        errorType: error.name,
+        message: error.message,
+        details: error.details 
+      });
+      return callback(error);
+    }
+
+    // Handle async database operations with proper callback handling
+    this.processDataRequest(schema, table, id, parseInt(pgLimit), callback);
+  }
+
+  async processDataRequest(schema, table, id, limit, callback) {
     try {
-      const splitPath = req.params.id.split('.');
-      schema = splitPath[0];
-      table = splitPath[1];
-      id = process.env.PG_OBJECTID || 'gid';
-      const pgLimit = process.env.PG_LIMIT || 10000000;
-
-      if (!table) {
-        throw new ValidationError('The "id" parameter must be in the form of "schema.table"', { 
-          providedId: req.params.id,
-          schema,
-          table 
-        });
-      }
-
       const geomColumnName = await db.data.getGeometryColumnName(schema, table);
+      
       if (!geomColumnName || !geomColumnName.f_geometry_column || !geomColumnName.srid) {
         log.warn('Table does not have a geometry column', { schema, table });
         return callback(null, {
@@ -43,7 +53,6 @@ class Model {
       
       const geom = geomColumnName.f_geometry_column;
       const srid = geomColumnName.srid;
-      const limit = parseInt(pgLimit);
       const offset = 0;
 
       const geojson = await db.data.createGeoJson(id, geom, srid, schema + '.' + table, limit, offset);
@@ -81,8 +90,7 @@ class Model {
           message: error.message,
           details: error.details 
         });
-        callback(error);
-        return;
+        return callback(error);
       }
 
       const dbError = new DatabaseError(

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -84,29 +84,32 @@ describe('Model Error Handling', () => {
   })
 
   describe('getData database errors', () => {
-    test('should wrap database errors as DatabaseError', async () => {
+    test('should wrap database errors as DatabaseError', (done) => {
       const req = { params: { id: 'schema.table' } }
       const dbError = new Error('Connection failed')
       db.data.getGeometryColumnName.mockRejectedValue(dbError)
 
-      await model.getData(req, mockCallback)
+      const callback = (error, result) => {
+        try {
+          expect(error).toBeInstanceOf(DatabaseError)
+          expect(error.message).toBe('Failed to retrieve data from PostGIS')
+          expect(error.originalError).toBe(dbError)
+          expect(error.details).toEqual({
+            schema: 'schema',
+            table: 'table',
+            id: 'gid'
+          })
+          expect(error.statusCode).toBe(500)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
 
-      expect(mockCallback).toHaveBeenCalledWith(
-        expect.any(DatabaseError)
-      )
-
-      const error = mockCallback.mock.calls[0][0]
-      expect(error.message).toBe('Failed to retrieve data from PostGIS')
-      expect(error.originalError).toBe(dbError)
-      expect(error.details).toEqual({
-        schema: 'schema',
-        table: 'table',
-        id: 'gid'
-      })
-      expect(error.statusCode).toBe(500)
+      model.getData(req, callback)
     })
 
-    test('should handle createGeoJson database errors', async () => {
+    test('should handle createGeoJson database errors', (done) => {
       const req = { params: { id: 'schema.table' } }
       const dbError = new Error('Query failed')
       
@@ -116,17 +119,20 @@ describe('Model Error Handling', () => {
       })
       db.data.createGeoJson.mockRejectedValue(dbError)
 
-      await model.getData(req, mockCallback)
+      const callback = (error, result) => {
+        try {
+          expect(error).toBeInstanceOf(DatabaseError)
+          expect(error.originalError).toBe(dbError)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
 
-      expect(mockCallback).toHaveBeenCalledWith(
-        expect.any(DatabaseError)
-      )
-
-      const error = mockCallback.mock.calls[0][0]
-      expect(error.originalError).toBe(dbError)
+      model.getData(req, callback)
     })
 
-    test('should handle unexpected GeoJSON result', async () => {
+    test('should handle unexpected GeoJSON result', (done) => {
       const req = { params: { id: 'schema.table' } }
       
       db.data.getGeometryColumnName.mockResolvedValue({
@@ -135,20 +141,28 @@ describe('Model Error Handling', () => {
       })
       db.data.createGeoJson.mockResolvedValue(null) // unexpected result
 
-      await model.getData(req, mockCallback)
+      const callback = (error, result) => {
+        try {
+          expect(error).toBeNull()
+          expect(result).toEqual(expect.objectContaining({
+            type: 'FeatureCollection',
+            features: [],
+            metadata: expect.objectContaining({
+              description: 'no-data'
+            })
+          }))
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
 
-      expect(mockCallback).toHaveBeenCalledWith(null, expect.objectContaining({
-        type: 'FeatureCollection',
-        features: [],
-        metadata: expect.objectContaining({
-          description: 'no-data'
-        })
-      }))
+      model.getData(req, callback)
     })
   })
 
   describe('successful getData', () => {
-    test('should return valid GeoJSON with metadata', async () => {
+    test('should return valid GeoJSON with metadata', (done) => {
       const req = { params: { id: 'schema.table' } }
       const mockGeojson = {
         type: 'FeatureCollection',
@@ -167,19 +181,27 @@ describe('Model Error Handling', () => {
       })
       db.data.createGeoJson.mockResolvedValue(mockGeojson)
 
-      await model.getData(req, mockCallback)
+      const callback = (error, result) => {
+        try {
+          expect(error).toBeNull()
+          expect(result).toEqual(expect.objectContaining({
+            type: 'FeatureCollection',
+            features: mockGeojson.features,
+            description: 'PG Koop Feature Service',
+            metadata: expect.objectContaining({
+              title: 'schema',
+              name: 'schema.table',
+              idField: 'gid',
+              geometryType: 'Point'
+            })
+          }))
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
 
-      expect(mockCallback).toHaveBeenCalledWith(null, expect.objectContaining({
-        type: 'FeatureCollection',
-        features: mockGeojson.features,
-        description: 'PG Koop Feature Service',
-        metadata: expect.objectContaining({
-          title: 'schema',
-          name: 'schema.table',
-          idField: 'gid',
-          geometryType: 'Point'
-        })
-      }))
+      model.getData(req, callback)
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,11 +1584,6 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
 body-parser@^1.19.0, body-parser@1.20.3:
   version "1.20.3"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz"


### PR DESCRIPTION
Console logging deprecation warning on displaying of data

**Issue**
The warning `(node:53397) [DEP0174] DeprecationWarning: Calling promisify on a function that returns a Promise is likely a mistake` is caused by:

- Mixed async/callback pattern: The `getData` method was declared as `async` but used callback-style return
 - Koop framework confusion: Koop's core tried to `util.promisify()` an already `async` function

**Proposed Changes:**
- Removed Bluebird dependency - Switched to native Promises
- Fixed method pattern - Separated concerns:
  - `getData()` - synchronous callback-based method (no async keyword)
  - `processDataRequest()` - handles async database operations internally

**Test:**
- Test the server with clean logs (no more deprecation warnings)
- View src/view/map.html at http://localhost:8080 without console deprecation logs
- Make API requests to test PostGIS layers

